### PR TITLE
Python3 support

### DIFF
--- a/pydocumentdb/auth.py
+++ b/pydocumentdb/auth.py
@@ -2,9 +2,9 @@
 
 """Authorization helper functions.
 """
-
-from hashlib import sha256
+import base64
 import hmac
+from hashlib import sha256
 
 import pydocumentdb.http_constants as http_constants
 
@@ -58,7 +58,9 @@ def __GetAuthorizationTokenUsingMasterKey(verb,
         dict
 
     """
-    key = master_key.decode('base64')
+    # The master_key from Azure UI which the dev/user specifies is base64
+    # encoded.
+    key = base64.b64decode(master_key)
 
     # Skipping lower casing of resource_id_or_fullname since it may now contain "ID" of the resource as part of the fullname
     text = '{verb}\n{resource_type}\n{resource_id_or_fullname}\n{x_date}\n{http_date}\n'.format(

--- a/pydocumentdb/auth.py
+++ b/pydocumentdb/auth.py
@@ -69,8 +69,13 @@ def __GetAuthorizationTokenUsingMasterKey(verb,
         resource_id_or_fullname=(resource_id_or_fullname or ''),
         x_date=headers.get(http_constants.HttpHeaders.XDate, '').lower(),
         http_date=headers.get(http_constants.HttpHeaders.HttpDate, '').lower())
-   
-    body = text.decode('utf8')
+
+    try:
+        # Python2.7 - decode from bytestring to unicode utf-8 string
+        body = text.decode('utf8')
+    except AttributeError:
+        # Python3 convert string to bytes array with utf-8 encoding
+        body = bytes(text, 'utf-8')
 
     hm = hmac.new(key, body, sha256)
     signature = hm.digest().encode('base64')

--- a/pydocumentdb/auth.py
+++ b/pydocumentdb/auth.py
@@ -75,16 +75,18 @@ def __GetAuthorizationTokenUsingMasterKey(verb,
         body = text.decode('utf8')
     except AttributeError:
         # Python3 convert string to bytes array with utf-8 encoding
-        body = bytes(text, 'utf-8')
+        body = text.encode('utf-8')
 
     hm = hmac.new(key, body, sha256)
     digest = hm.digest()
     # Encode the digest for the signature
     try:
-        # Python3 uses encodebytes, encodestring is deprecated
-        signature = base64.encodebytes(digest)
+        # Python3 uses encodebytes, encodestring is deprecated.
+        # encodebytes returns bytes so decode to utf-8 string
+        signature = base64.encodebytes(digest).decode('utf-8')
     except AttributeError:
         # Python2.7 uses encodestring
+        # returns string
         signature = base64.encodestring(digest)
 
     master_token = 'master'

--- a/pydocumentdb/auth.py
+++ b/pydocumentdb/auth.py
@@ -78,7 +78,14 @@ def __GetAuthorizationTokenUsingMasterKey(verb,
         body = bytes(text, 'utf-8')
 
     hm = hmac.new(key, body, sha256)
-    signature = base64.b64encode(hm.digest())
+    digest = hm.digest()
+    # Encode the digest for the signature
+    try:
+        # Python3 uses encodebytes, encodestring is deprecated
+        signature = base64.encodebytes(digest)
+    except AttributeError:
+        # Python2.7 uses encodestring
+        signature = base64.encodestring(digest)
 
     master_token = 'master'
     token_version = '1.0'

--- a/pydocumentdb/auth.py
+++ b/pydocumentdb/auth.py
@@ -78,7 +78,7 @@ def __GetAuthorizationTokenUsingMasterKey(verb,
         body = bytes(text, 'utf-8')
 
     hm = hmac.new(key, body, sha256)
-    signature = hm.digest().encode('base64')
+    signature = base64.b64encode(hm.digest())
 
     master_token = 'master'
     token_version = '1.0'

--- a/pydocumentdb/backoff_retry_utility.py
+++ b/pydocumentdb/backoff_retry_utility.py
@@ -22,7 +22,7 @@ def Execute(callback_fn, resource_throttle_retry_policy):
         try:
             callback_fn()
             break  # Break from the while loop if no exception happened.
-        except Exception, e:
+        except Exception as e:
             should_retry = resource_throttle_retry_policy.ShouldRetry(e)
             if not should_retry:
                 raise

--- a/pydocumentdb/base.py
+++ b/pydocumentdb/base.py
@@ -6,7 +6,12 @@
 import base64
 import datetime
 import json
-import urllib
+
+try:
+    from urllib.parse import quote as urllib_quote
+except ImportError:
+    from urllib import quote as urllib_quote
+
 import uuid
 
 import pydocumentdb.auth as auth
@@ -113,7 +118,7 @@ def GetHeaders(document_client,
 
     if document_client.master_key or document_client.resource_tokens:
         # -_.!~*'() are valid characters in url, and shouldn't be quoted.
-        headers[http_constants.HttpHeaders.Authorization] = urllib.quote(
+        headers[http_constants.HttpHeaders.Authorization] = urllib_quote(
             auth.GetAuthorizationHeader(document_client,
                                         verb,
                                         path,
@@ -225,7 +230,7 @@ def GetPathFromLink(resource_link, resource_type=''):
     if IsNameBased(resource_link):
         # Replace special characters in string using the %xx escape. For example, space(' ') would be replaced by %20
         # This function is intended for quoting the path section of the URL and excludes '/' to be quoted as that's the default safe char
-        resource_link = urllib.quote(resource_link)
+        resource_link = urllib_quote(resource_link)
         
     # Padding leading and trailing slashes to the path returned both for name based and resource id based links
     if resource_type:

--- a/pydocumentdb/base.py
+++ b/pydocumentdb/base.py
@@ -103,9 +103,13 @@ def GetHeaders(document_client,
         headers[http_constants.HttpHeaders.OfferThroughput] = options['offerThroughput']
 
     if 'partitionKey' in options:
-        # if partitionKey value is Undefined, serailize it as {} to be consistent with other SDKs
+        # if partitionKey value is Undefined, serialize it as {} to be consistent with other SDKs
         if options.get('partitionKey') is documents.Undefined:
-            headers[http_constants.HttpHeaders.PartitionKey] = [{}]
+            import sys
+            if sys.version_info > (3,):
+                headers[http_constants.HttpHeaders.PartitionKey] = '[{}]'.encode('utf-8')
+            else:
+                headers[http_constants.HttpHeaders.PartitionKey] = [{}]
         # else serialize using json dumps method which apart from regular values will serialize None into null
         else:
             headers[http_constants.HttpHeaders.PartitionKey] = json.dumps([options['partitionKey']])

--- a/pydocumentdb/base.py
+++ b/pydocumentdb/base.py
@@ -6,6 +6,7 @@
 import base64
 import datetime
 import json
+import sys
 
 try:
     from urllib.parse import quote as urllib_quote
@@ -189,13 +190,20 @@ def GetAttachmentIdFromMediaId(media_id):
 
     """
     altchars = '+-'
+    if sys.version_info > (3,):
+        # Python3 httpclient ssl connection expects bytes data
+        altchars = altchars.encode('utf-8')
     # altchars for '+' and '/'. We keep '+' but replace '/' with '-'
     buffer = base64.b64decode(str(media_id), altchars)
     resoure_id_length = 20
     attachment_id = ''
     if len(buffer) > resoure_id_length:
-        # We are cuting off the storage index.
+        # We are cutting off the storage index.
         attachment_id = base64.b64encode(buffer[0:resoure_id_length], altchars)
+        if sys.version_info > (3,):
+            # Python3: further code which uses the attachment_id expects it to
+            # be a string, not bytes.
+            attachment_id = attachment_id.decode('utf-8')
     else:
         attachment_id = media_id
 

--- a/pydocumentdb/consistent_hash_ring.py
+++ b/pydocumentdb/consistent_hash_ring.py
@@ -20,7 +20,16 @@
 #SOFTWARE.
 
 import pydocumentdb.partition as partition
+
 from struct import *
+
+
+try:
+    basestring
+except NameError:
+    # Python3 doesn't have basestring
+    basestring = (str, bytes)
+
 
 class _ConsistentHashRing(object):
     """The ConsistentHashRing class implements a consistent hash ring using the 

--- a/pydocumentdb/https_connection.py
+++ b/pydocumentdb/https_connection.py
@@ -6,11 +6,11 @@
 
 import socket
 import ssl
-
+import sys
 
 try:
     from httplib import HTTPConnection, HTTPS_PORT
-except:
+except ImportError:
     from http.client import HTTPConnection, HTTPS_PORT
 
 
@@ -30,7 +30,13 @@ class HTTPSConnection(HTTPConnection):
             - `timeout`: int, the connection timeout in milliseconds.
             - `source_address`: str, the source address.
         """
-        HTTPConnection.__init__(self, host, port, strict, timeout, source_address)
+        if sys.version_info > (3,):
+            # Python3 doesn't expect the strict parameter.
+            HTTPConnection.__init__(self, host, port, timeout, source_address)
+        else:
+            HTTPConnection.__init__(self, host, port, strict,
+                                    timeout, source_address)
+
         self._ssl_configuration = ssl_configuration
 
     def connect(self):

--- a/pydocumentdb/murmur_hash.py
+++ b/pydocumentdb/murmur_hash.py
@@ -21,6 +21,13 @@
 
 from struct import *
 
+
+try:
+    xrange
+except NameError:
+    # In Python3 range is xrange
+    xrange = range
+
 '''
 pymmh3 was written by Fredrik Kihlander, and is placed in the public
 domain. The author hereby disclaims copyright to this source code.

--- a/pydocumentdb/partition.py
+++ b/pydocumentdb/partition.py
@@ -40,7 +40,16 @@ class _Partition(object):
         return self.CompareTo(other.hash_value)
 
     def __lt__(self, other):
-        return self.__cmp__(other)
+        val = self.__cmp__(other)
+        # CompareTo (and therefore __cmp__) return a negative value for less
+        # than, and positive for greater than. __lt__ must return a boolean
+        # meaning 'is self less than other'.
+        # First change -1 to 0 which is False (-1 is True), then
+        # return the opposite of the return value from __cmp__ to align with
+        # expected response from __lt__.
+        if val == -1:
+            val = 0
+        return not bool(val)
 
     def CompareTo(self, other_hash_value):
         """Compares the passed hash value with the hash value of this object

--- a/pydocumentdb/partition.py
+++ b/pydocumentdb/partition.py
@@ -38,7 +38,10 @@ class _Partition(object):
         if self == other:
             return 0
         return self.CompareTo(other.hash_value)
-    
+
+    def __lt__(self, other):
+        return self.__cmp__(other)
+
     def CompareTo(self, other_hash_value):
         """Compares the passed hash value with the hash value of this object
         """

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -107,6 +107,7 @@ def _InternalRequest(connection_policy, request_options, request_body):
         return (response, headers)
 
     data = response.read()
+    connection.close()
     if response.status >= 400:
         raise errors.HTTPFailure(response.status, data, headers)
 

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -160,8 +160,7 @@ def SynchronizedRequest(connection_policy,
         request_options['path'] += '?' + urllib.urlencode(query_params)
 
     request_options['headers'] = headers
-    if request_body and (type(request_body) is str or
-                         type(request_body) is unicode):
+    if request_body and (type(request_body) is str):
         request_options['headers'][http_constants.HttpHeaders.ContentLength] = (
             len(request_body))
     elif request_body == None:

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -147,9 +147,9 @@ def SynchronizedRequest(connection_policy,
     if request_data:
         request_body = _RequestBodyFromData(request_data)
         if not request_body:
-           raise errors.UnexpectedDataType(
-               'parameter data must be a JSON object, string or' +
-               ' readable stream.')
+            raise errors.UnexpectedDataType(
+                'parameter data must be a JSON object, string or' +
+                ' readable stream.')
 
     request_options = {}
     parse_result = urlparse.urlparse(base_url)

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -4,6 +4,7 @@
 """
 
 import json
+import sys
 try:
     import urlparse
 except ImportError:
@@ -36,7 +37,7 @@ except NameError:
 
 
 def _RequestBodyFromData(data):
-    """Gets requestion body from data.
+    """Gets request body from data.
 
     When `data` is dict and list into unicode string; otherwise return `data`
     without making any change.
@@ -109,10 +110,10 @@ def _InternalRequest(connection_policy, request_options, request_body):
         result = data
     else:
         if len(data) > 0:
-            try:
-                result = json.loads(data)
-            except:
-                raise errors.JSONParseFailure(data)
+            # In Python3 data is utf8 encoded bytes, decode to string for json
+            if sys.version_info > (3,):
+                data = data.decode('utf-8')
+            result = json.loads(data)
 
     return (result, headers)
 

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -33,6 +33,12 @@ try:
 except NameError:
     basestring = (str, bytes)
 
+try:
+    unicode
+except NameError:
+    # Python3 doesn't have unicode as a keyword
+    unicode = None
+
 
 def _RequestBodyFromData(data):
     """Gets request body from data.
@@ -159,7 +165,9 @@ def SynchronizedRequest(connection_policy,
         request_options['path'] += '?' + urlparse.urlencode(query_params)
 
     request_options['headers'] = headers
-    if request_body and (type(request_body) is str):
+    if (request_body and
+            (type(request_body) in [str, bytes] or
+             (unicode is not None and type(request_body) is unicode))):
         request_options['headers'][http_constants.HttpHeaders.ContentLength] = (
             len(request_body))
     elif request_body is None:

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -10,8 +10,6 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
-import urllib
-
 import pydocumentdb.documents as documents
 import pydocumentdb.errors as errors
 import pydocumentdb.http_constants as http_constants

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -51,8 +51,10 @@ def _RequestBodyFromData(data):
     if isinstance(data, basestring) or _IsReadableStream(data):
         return data
     elif isinstance(data, (dict, list, tuple)):
-        return json.dumps(data, separators=(',',':')).decode('utf8')
-    return None
+        jsonstr = json.dumps(data, separators=(',', ':'))
+        if isinstance(jsonstr, bytes):
+            jsonstr = jsonstr.decode('utf8')
+    return jsonstr
 
 
 def _InternalRequest(connection_policy, request_options, request_body):

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -4,7 +4,11 @@
 """
 
 import json
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
 import urllib
 
 import pydocumentdb.documents as documents

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -49,6 +49,7 @@ def _RequestBodyFromData(data):
         str, unicode, file-like stream object, or None
 
     """
+    jsonstr = None
     if isinstance(data, basestring) or _IsReadableStream(data):
         return data
     elif isinstance(data, (dict, list, tuple)):
@@ -157,12 +158,12 @@ def SynchronizedRequest(connection_policy,
     request_options['path'] = path
     request_options['method'] = method
     if query_params:
-        request_options['path'] += '?' + urllib.urlencode(query_params)
+        request_options['path'] += '?' + urlparse.urlencode(query_params)
 
     request_options['headers'] = headers
     if request_body and (type(request_body) is str):
         request_options['headers'][http_constants.HttpHeaders.ContentLength] = (
             len(request_body))
-    elif request_body == None:
+    elif request_body is None:
         request_options['headers'][http_constants.HttpHeaders.ContentLength] = 0
     return _InternalRequest(connection_policy, request_options, request_body)

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -1869,11 +1869,11 @@ class CRUDTests(unittest.TestCase):
 
     # Upsert test for Attachment resource - selflink version
     def test_attachment_upsert_self_link(self):
-        self._test_attachment_upsert(False);
+        self._test_attachment_upsert(False)
 
     # Upsert test for Attachment resource - name based routing version
     def test_attachment_upsert_name_based(self):
-        self._test_attachment_upsert(True);
+        self._test_attachment_upsert(True)
         
     def _test_attachment_upsert(self, is_name_based):
         client = document_client.DocumentClient(host,
@@ -3584,35 +3584,35 @@ class CRUDTests(unittest.TestCase):
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id ends with a space.', e.message)
+            self.assertEqual('Id ends with a space.', str(e))
         # Id shouldn't contain '/'.
         database_definition = { 'id': 'id_with_illegal/_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
         # Id shouldn't contain '\\'.
         database_definition = { 'id': 'id_with_illegal\\_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
         # Id shouldn't contain '?'.
         database_definition = { 'id': 'id_with_illegal?_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
         # Id shouldn't contain '#'.
         database_definition = { 'id': 'id_with_illegal#_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
 
         # Id can begin with space
         database_definition = { 'id': ' id_begin_space' }

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -9,6 +9,13 @@ import json
 import os.path
 
 import pydocumentdb.documents as documents
+try:
+    # Python2.7
+    from __builtin__ import *
+except ImportError:
+    # Python3
+    import builtins
+
 import pydocumentdb.document_client as document_client
 import pydocumentdb.errors as errors
 import pydocumentdb.http_constants as http_constants

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -48,6 +48,48 @@ if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
 #  	To Run the test, replace the two member fields (masterKey and host) with values 
 #   associated with your DocumentDB account.
 
+
+class ReadableStream(object):
+    """Customized file-like stream.
+    """
+
+    def __init__(self, chunks=None):
+        """Initialization.
+
+        :Parameters:
+            - `chunks`: list
+
+        """
+        if chunks is None:
+            chunks = ['first chunk ', 'second chunk']
+
+        if sys.version_info > (3,):
+            # Python3 httpclient ssl connection expects bytes data
+            chunks = [c.encode('utf-8') for c in chunks]
+
+        self._chunks = chunks
+
+    def read(self, n=-1):
+        """Simulates the read method in a file stream.
+
+        :Parameters:
+            - `n`: int
+
+        :Returns:
+            str
+
+        """
+        if self._chunks:
+            return self._chunks.pop(0)
+        else:
+            return ''
+
+    def __len__(self):
+        """To make len(ReadableStream) work.
+        """
+        return sum([len(chunk) for chunk in self._chunks])
+
+
 class CRUDTests(unittest.TestCase):
     """Python CRUD Tests.
     """
@@ -648,38 +690,7 @@ class CRUDTests(unittest.TestCase):
         client.DeleteCollection(self.GetDocumentCollectionLink(created_db, created_collection))
 
     def test_partitioned_collection_attachment_crud_and_query(self):
-        class ReadableStream(object):
-            """Customized file-like stream.
-            """
 
-            def __init__(self, chunks = ['first chunk ', 'second chunk']):
-                """Initialization.
-
-                :Parameters:
-                    - `chunks`: list
-
-                """
-                self._chunks = list(chunks)
-
-            def read(self, n=-1):
-                """Simulates the read method in a file stream.
-
-                :Parameters:
-                    - `n`: int
-
-                :Returns:
-                    str
-
-                """
-                if self._chunks:
-                    return self._chunks.pop(0)
-                else:
-                    return ''
-
-            def __len__(self):
-                """To make len(ReadableStream) work.
-                """
-                return sum([len(chunk) for chunk in self._chunks])
 
 
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
@@ -1733,47 +1744,6 @@ class CRUDTests(unittest.TestCase):
         self._test_attachment_crud(True);
         
     def _test_attachment_crud(self, is_name_based):
-        class ReadableStream(object):
-            """Customized file-like stream.
-            """
-
-            def __init__(self, chunks=None):
-                """Initialization.
-
-                :Parameters:
-                    - `chunks`: list
-
-                """
-                if chunks is None:
-                    chunks = ['first chunk ', 'second chunk']
-
-                if sys.version_info > (3,):
-                    # Python3 httpclient ssl connection expects bytes data
-                    chunks = [c.encode('utf-8') for c in chunks]
-
-                self._chunks = chunks
-
-            def read(self, n=-1):
-                """Simulates the read method in a file stream.
-
-                :Parameters:
-                    - `n`: int
-
-                :Returns:
-                    str
-
-                """
-                if self._chunks:
-                    return self._chunks.pop(0)
-                else:
-                    return ''
-
-            def __len__(self):
-                """To make len(ReadableStream) work.
-                """
-                return sum([len(chunk) for chunk in self._chunks])
-
-
         # Should do attachment CRUD operations successfully
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
@@ -1906,39 +1876,6 @@ class CRUDTests(unittest.TestCase):
         self._test_attachment_upsert(True);
         
     def _test_attachment_upsert(self, is_name_based):
-        class ReadableStream(object):
-            """Customized file-like stream.
-            """
-
-            def __init__(self, chunks = ['first chunk ', 'second chunk']):
-                """Initialization.
-
-                :Parameters:
-                    - `chunks`: list
-
-                """
-                self._chunks = list(chunks)
-
-            def read(self, n=-1):
-                """Simulates the read method in a file stream.
-
-                :Parameters:
-                    - `n`: int
-
-                :Returns:
-                    str
-
-                """
-                if self._chunks:
-                    return self._chunks.pop(0)
-                else:
-                    return ''
-
-            def __len__(self):
-                """To make len(ReadableStream) work.
-                """
-                return sum([len(chunk) for chunk in self._chunks])
-
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -1825,7 +1825,7 @@ class CRUDTests(unittest.TestCase):
         # read attachment media
         media_response = client.ReadMedia(valid_attachment['media'])
         self.assertEqual(media_response,
-                         'first chunk second chunk')
+                         b'first chunk second chunk')
         content_stream = ReadableStream(['modified first chunk ',
                                          'modified second chunk'])
         # update attachment media
@@ -1836,13 +1836,13 @@ class CRUDTests(unittest.TestCase):
         # read media buffered
         media_response = client.ReadMedia(valid_attachment['media'])
         self.assertEqual(media_response,
-                         'modified first chunk modified second chunk')
+                         b'modified first chunk modified second chunk')
         # read media streamed
         client.connection_policy.MediaReadMode = (
             documents.MediaReadMode.Streamed)
         media_response = client.ReadMedia(valid_attachment['media'])
         self.assertEqual(media_response.read(),
-                         'modified first chunk modified second chunk')
+                         b'modified first chunk modified second chunk')
         # share attachment with a second document
         document = client.CreateDocument(self.GetDocumentCollectionLink(db, collection, is_name_based),
                                          {'id': 'document 2'})

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -3,12 +3,10 @@
 """End to end test.
 """
 
-import logging
-import unittest
 import json
 import os.path
+import unittest
 
-import pydocumentdb.documents as documents
 try:
     # Python2.7
     from __builtin__ import *
@@ -16,18 +14,19 @@ except ImportError:
     # Python3
     import builtins
 
-import pydocumentdb.document_client as document_client
-import pydocumentdb.errors as errors
-import pydocumentdb.http_constants as http_constants
-import pydocumentdb.hash_partition_resolver as hash_partition_resolver
-import pydocumentdb.range_partition_resolver as range_partition_resolver
-import pydocumentdb.murmur_hash as murmur_hash
-import pydocumentdb.consistent_hash_ring as consistent_hash_ring
-import pydocumentdb.range as partition_range
-import test_partition_resolver as test_partition_resolver
-import pydocumentdb.base as base
-
 from struct import *
+
+import pydocumentdb.base as base
+import pydocumentdb.consistent_hash_ring as consistent_hash_ring
+import pydocumentdb.document_client as document_client
+import pydocumentdb.documents as documents
+import pydocumentdb.errors as errors
+import pydocumentdb.hash_partition_resolver as hash_partition_resolver
+import pydocumentdb.http_constants as http_constants
+import pydocumentdb.murmur_hash as murmur_hash
+import pydocumentdb.range as partition_range
+import pydocumentdb.range_partition_resolver as range_partition_resolver
+import test_partition_resolver as test_partition_resolver
 
 TEST_DB_NAME = 'sample database'
 
@@ -1403,16 +1402,16 @@ class CRUDTests(unittest.TestCase):
             collection_link = self.GetDocumentCollectionLink(created_db, collection, True)
             collection_links.append(collection_link)
 
-        expected_partition_list.append(('dbs/db/colls/coll0', 1076200484L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 1302652881L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 2210251988L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 2341558382L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 2348251587L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 2887945459L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 2894403633L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 3031617259L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 3090861424L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 4222475028L))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(1076200484)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(1302652881)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(2210251988)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(2341558382)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(2348251587)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(2887945459)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(2894403633)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(3031617259)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(3090861424)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(4222475028)))
 
         id_partition_key_extractor = lambda document: document['id']
         
@@ -1451,29 +1450,29 @@ class CRUDTests(unittest.TestCase):
         bytes = bytearray(str, encoding='utf-8')
 
         hash_value = murmur_hash._MurmurHash._ComputeHash(bytes)
-        self.assertEqual(1099701186L, hash_value)
+        self.assertEqual(long(1099701186), hash_value)
 
         num = 374.0
         bytes = bytearray(pack('d', num))
 
         hash_value = murmur_hash._MurmurHash._ComputeHash(bytes)
-        self.assertEqual(3717946798L, hash_value)
+        self.assertEqual(long(3717946798), hash_value)
 
-        self._validate_bytes("", 0x1B873593, bytearray(b'\xEE\xA8\xA2\x67'), 1738713326L);
-        self._validate_bytes("1", 0xE82562E4, bytearray(b'\xD0\x92\x24\xED'), 3978597072L);
-        self._validate_bytes("00", 0xB4C39035, bytearray(b'\xFA\x09\x64\x1B'), 459540986L);
-        self._validate_bytes("eyetooth", 0x8161BD86, bytearray(b'\x98\x62\x1C\x6F'), 1864131224L);
-        self._validate_bytes("acid", 0x4DFFEAD7, bytearray(b'\x36\x92\xC0\xB9'), 3116405302L);
-        self._validate_bytes("elevation", 0x1A9E1828, bytearray(b'\xA9\xB6\x40\xDF'), 3745560233L);
-        self._validate_bytes("dent", 0xE73C4579, bytearray(b'\xD4\x59\xE1\xD3'), 3554761172L);
-        self._validate_bytes("homeland", 0xB3DA72CA, bytearray(b'\x06\x4D\x72\xBB'), 3144830214L);
-        self._validate_bytes("glamor", 0x8078A01B, bytearray(b'\x89\x89\xA2\xA7'), 2812447113L);
-        self._validate_bytes("flags", 0x4D16CD6C, bytearray(b'\x52\x87\x66\x02'), 40273746L);
-        self._validate_bytes("democracy", 0x19B4FABD, bytearray(b'\xE4\x55\xD6\xB0'), 2966836708L);
-        self._validate_bytes("bumble", 0xE653280E, bytearray(b'\xFE\xD7\xC3\x0C'), 214161406L);
-        self._validate_bytes("catch", 0xB2F1555F, bytearray(b'\x98\x4B\xB6\xCD'), 3451276184L);
-        self._validate_bytes("omnomnomnivore", 0x7F8F82B0, bytearray(b'\x38\xC4\xCD\xFF'), 4291675192L);
-        self._validate_bytes("The quick brown fox jumps over the lazy dog", 0x4C2DB001, bytearray(b'\x6D\xAB\x8D\xC9'), 3381504877L)
+        self._validate_bytes("", 0x1B873593, bytearray(b'\xEE\xA8\xA2\x67'), long(1738713326))
+        self._validate_bytes("1", 0xE82562E4, bytearray(b'\xD0\x92\x24\xED'), long(3978597072))
+        self._validate_bytes("00", 0xB4C39035, bytearray(b'\xFA\x09\x64\x1B'), long(459540986))
+        self._validate_bytes("eyetooth", 0x8161BD86, bytearray(b'\x98\x62\x1C\x6F'), long(1864131224))
+        self._validate_bytes("acid", 0x4DFFEAD7, bytearray(b'\x36\x92\xC0\xB9'), long(3116405302))
+        self._validate_bytes("elevation", 0x1A9E1828, bytearray(b'\xA9\xB6\x40\xDF'), long(3745560233))
+        self._validate_bytes("dent", 0xE73C4579, bytearray(b'\xD4\x59\xE1\xD3'), long(3554761172))
+        self._validate_bytes("homeland", 0xB3DA72CA, bytearray(b'\x06\x4D\x72\xBB'), long(3144830214))
+        self._validate_bytes("glamor", 0x8078A01B, bytearray(b'\x89\x89\xA2\xA7'), long(2812447113))
+        self._validate_bytes("flags", 0x4D16CD6C, bytearray(b'\x52\x87\x66\x02'), long(40273746))
+        self._validate_bytes("democracy", 0x19B4FABD, bytearray(b'\xE4\x55\xD6\xB0'), long(2966836708))
+        self._validate_bytes("bumble", 0xE653280E, bytearray(b'\xFE\xD7\xC3\x0C'), long(214161406))
+        self._validate_bytes("catch", 0xB2F1555F, bytearray(b'\x98\x4B\xB6\xCD'), long(3451276184))
+        self._validate_bytes("omnomnomnivore", 0x7F8F82B0, bytearray(b'\x38\xC4\xCD\xFF'), long(4291675192))
+        self._validate_bytes("The quick brown fox jumps over the lazy dog", 0x4C2DB001, bytearray(b'\x6D\xAB\x8D\xC9'), long(3381504877))
 
     def _validate_bytes(self, str, seed, expected_hash_bytes, expected_value):
         hash_value = murmur_hash._MurmurHash._ComputeHash(bytearray(str, encoding='utf-8'), seed)

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -1744,14 +1744,14 @@ class CRUDTests(unittest.TestCase):
                     - `chunks`: list
 
                 """
-                self._chunks = []
                 if chunks is None:
                     chunks = ['first chunk ', 'second chunk']
-                    if sys.version_info > (3,):
-                        # Python3 httpclient ssl connection expects bytes data
-                        chunks = [c.encode('utf-8') for c in chunks]
 
-                    self._chunks = list(chunks)
+                if sys.version_info > (3,):
+                    # Python3 httpclient ssl connection expects bytes data
+                    chunks = [c.encode('utf-8') for c in chunks]
+
+                self._chunks = chunks
 
             def read(self, n=-1):
                 """Simulates the read method in a file stream.

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -6,6 +6,7 @@
 import json
 import os.path
 import unittest
+import sys
 
 try:
     # Python2.7
@@ -15,7 +16,6 @@ except ImportError:
     import builtins
 
 from struct import *
-
 import pydocumentdb.base as base
 import pydocumentdb.consistent_hash_ring as consistent_hash_ring
 import pydocumentdb.document_client as document_client
@@ -26,7 +26,11 @@ import pydocumentdb.http_constants as http_constants
 import pydocumentdb.murmur_hash as murmur_hash
 import pydocumentdb.range as partition_range
 import pydocumentdb.range_partition_resolver as range_partition_resolver
-import test_partition_resolver as test_partition_resolver
+import test.test_partition_resolver as test_partition_resolver
+
+# If Python3, set long to int
+if sys.version_info > (3,):
+    long = int
 
 TEST_DB_NAME = 'sample database'
 
@@ -35,7 +39,6 @@ if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
     raise Exception(
         "You must specify your Azure DocumentDB account values for "
         "'masterKey' and 'host' at the top of this file to run the tests.")
-
 
 #IMPORTANT NOTES:
   

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -1737,14 +1737,21 @@ class CRUDTests(unittest.TestCase):
             """Customized file-like stream.
             """
 
-            def __init__(self, chunks = ['first chunk ', 'second chunk']):
+            def __init__(self, chunks=None):
                 """Initialization.
 
                 :Parameters:
                     - `chunks`: list
 
                 """
-                self._chunks = list(chunks)
+                self._chunks = []
+                if chunks is None:
+                    chunks = ['first chunk ', 'second chunk']
+                    if sys.version_info > (3,):
+                        # Python3 httpclient ssl connection expects bytes data
+                        chunks = [c.encode('utf-8') for c in chunks]
+
+                    self._chunks = list(chunks)
 
             def read(self, n=-1):
                 """Simulates the read method in a file stream.

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -28,7 +28,6 @@ import test_partition_resolver as test_partition_resolver
 import pydocumentdb.base as base
 
 from struct import *
-from __builtin__ import *
 
 TEST_DB_NAME = 'sample database'
 


### PR DESCRIPTION
local PR for the fork PR53 merge to [Azure/azure-documentdb-python](https://github.com/Azure/azure-documentdb-python/pull/53).

This PR adds support for python3, while maintaining support for python2.7.

Where possible I've used `try`/`except`:

``` python
try:
    python2.7 code
except AttributeError:
    python3.5 code
```

In some cases I had to resort to checking the `sys.version_info` and determining the code path based on that.

Please pay extra close attention to the changes I made to `__GetAuthorizationTokenUsingMasterKey` as this is used in all request auth header generation.

Note: This was branched from the branch in PR #51, and therefore includes the changes made for PR #51.
# Unittests
### master test status:

`crud_tests.py` gives many `429` Request Rate too high errors, so it's difficult to fully test when branching/making changes. See #49.
- test/crud_tests.py
  Ran 72 tests, 33 errors:
  - `test_attachment_crud_self_link`:
    Fails intermittently/randomly. See Issue #52
  - `test_partitioned_collection_path_parser`:
    `
      FileNotFoundError: [Errno 2] No such file or directory: '/Users/<name>/.net/Microsoft.Azure.Documents.Client.Test/Routing/resources/BaselineTest.PathParser.json
    `
  - `test_id_validation`:
    `
    {"code":"Conflict","message":"Message: {\\"Errors\\":[\\"Resource with specified id or name already exists\\"
    `
  - `test_offer_replace`:
    `pydocumentdb.errors.HTTPFailure: Status code: 400
    b'{"code":"BadRequest","message":"Offer type is not supported with Offer version \'V2\' and above.\\r\\nActivityId: f7758066-ddd7-4521-b72d-a220ce6ed37b"}'
    `
    - `test_sql_query_crud`
    `HTTPFailure: Status code: 409`
    `{"code":"Conflict","message":"Message: {\"Errors\":[\"Resource with specified id or name already exists\"]}`
- python test/ttl_tests.py:
  pass
### python3 branch unittests using `python3.5` & `python2.7`:
- test/crud_tests.py - same as master.
- python test/ttl_tests.py - pass - same as master.
## HTTP Connection closure

Python3 warns:

``` bash
/Projects/azure-documentdb-python/pydocumentdb/synchronized_request.py:179: 
ResourceWarning: unclosed <ssl.SSLSocket fd=4, 
family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, 
proto=6, laddr=(<addr ommitted>), raddr=(<addr ommitted>)>
```

the code now explicitly closes HTTP connections _except in the streaming case_. If the data is streamed then the response is passed back, then this needs some other mechanism for the user/API to close the connection when streaming is complete, as immediate closure won’t work.
