### PR TITLE
Don't use the `logging` module directly to emit messages.

### DIFF
--- a/pydocumentdb/backoff_retry_utility.py
+++ b/pydocumentdb/backoff_retry_utility.py
@@ -10,6 +10,9 @@ import pydocumentdb.errors as errors
 import pydocumentdb.http_constants as http_constants
 
 
+logger = logging.getLogger()
+
+
 def Execute(callback_fn, resource_throttle_retry_policy):
     """Exectutes the callback function using the resource_throttle_retry_policy.
 
@@ -54,12 +57,12 @@ class ResourceThrottleRetryPolicy(object):
         if (self._current_attempt_count < self._max_attempt_count and
                 self._CheckIfRetryNeeded(exception)):
             self._current_attempt_count += 1
-            logging.info('Operation will be retried after %d milliseconds. Exception: %s' %
+            logger.info('Operation will be retried after %d milliseconds. Exception: %s' %
                          (self.retry_after_in_milliseconds,
                           str(exception)))
             return True
         else:
-            logging.warning('Operation will NOT be retried. Exception: %s' %
+            logger.warning('Operation will NOT be retried. Exception: %s' %
                             str(exception))
             return False
 

--- a/pydocumentdb/endpoint_discovery_retry_policy.py
+++ b/pydocumentdb/endpoint_discovery_retry_policy.py
@@ -24,6 +24,10 @@ import time
 
 import pydocumentdb.errors as errors
 
+logger = logging.basicConfig(format='%(levelname)s:%(message)s',
+                             level=logging.INFO)
+
+
 def _Execute(endpoint_discovery_retry_policy, function, *args, **kwargs):
     """Exectutes the callback function using the endpoint_discovery_retry_policy.
 
@@ -66,7 +70,6 @@ class _EndpointDiscoveryRetryPolicy(object):
         self._max_retry_attempt_count = _EndpointDiscoveryRetryPolicy.Max_retry_attempt_count
         self._current_retry_attempt_count = 0
         self.retry_after_in_milliseconds = _EndpointDiscoveryRetryPolicy.Retry_after_in_milliseconds
-        logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
     def ShouldRetry(self, exception):
         """Returns true if should retry on the passed-in exception.
@@ -83,13 +86,13 @@ class _EndpointDiscoveryRetryPolicy(object):
             self._current_retry_attempt_count += 1
             return True
         else:
-            logging.info('Operation will NOT be retried or has maxed out the retry count. Exception: %s' % str(exception))
+            logger.info('Operation will NOT be retried or has maxed out the retry count. Exception: %s' % str(exception))
             return False
 
     def _CheckIfRetryNeeded(self, exception):
         # Check if it's a write-forbidden exception, which has StatusCode=403 and SubStatus=3 and whether EnableEndpointDiscovery is set to True
         if (isinstance(exception, errors.HTTPFailure) and exception.status_code == 403 and exception.sub_status == 3 and self.global_endpoint_manager.EnableEndpointDiscovery):
-            logging.info('Write location was changed, refreshing the locations list from database account and will retry the request.')
+            logger.info('Write location was changed, refreshing the locations list from database account and will retry the request.')
             return True
 
         return False


### PR DESCRIPTION
It auto-creates another root logger, rather than using any
pre-configured loggers created by code using azure-documentdb-python, which results in any log messages from the external code being emitted an extra time via this root logger.
